### PR TITLE
Fix plot error when effect size is 0

### DIFF
--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -530,6 +530,9 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
             # If the effect size is negative, shift the contrast axis down.
             elif current_effsize < 0:
                 rightmin, rightmax = rawdata_ylims + current_effsize
+            else:
+                rightmin, rightmax = rawdata_ylims
+
             contrast_axes.set_ylim(rightmin, rightmax)
 
             # align statfunc(exp) on rawdata_axes with the effect size on contrast_axes.


### PR DESCRIPTION
First off, thank you for providing this library! It's very well-designed. 

This fixes the following error when running the plotter with a data set that has an effect size of exactly 0 and a type of "median_diff" or "mean_diff":

    UnboundLocalError: local variable 'rightmin' referenced before assignment

Reproduction code (I could turn this into a test, but I'm not sure it's worth it):
```py
import pandas as pd
import dabest

df = pd.DataFrame({"one": range(1, 10), "two": range(1, 10)})
dabest.load(df, idx=("one", "two")).median_diff.plot()
```