### PR TITLE
Inset axes

### DIFF
--- a/dabest/_classes.py
+++ b/dabest/_classes.py
@@ -44,16 +44,16 @@ class Dabest(object):
             if len(idx) > len(all_plot_groups):
                 err0 = '`idx` contains duplicated groups. Please remove any duplicates and try again.'
                 raise ValueError(err0)
-
+                
             # We need to re-wrap this idx inside another tuple so as to
             # easily loop thru each pairwise group later on.
             self.__idx = (idx,)
 
         elif all([isinstance(i, (tuple, list)) for i in idx]):
             all_plot_groups = pd.unique([tt for t in idx for tt in t]).tolist()
-
+            
             actual_groups_given = sum([len(i) for i in idx])
-
+            
             if actual_groups_given > len(all_plot_groups):
                 err0 = 'Groups are repeated across tuples,'
                 err1 = ' or a tuple has repeated groups in it.'
@@ -107,10 +107,10 @@ class Dabest(object):
                     err1 = " Please check `idx` and try again."
                     raise IndexError(err0 + err1)
 
-            # Select only rows where the value in the `x` column
+            # Select only rows where the value in the `x` column 
             # is found in `idx`.
             plot_data = data_in[data_in.loc[:, x].isin(all_plot_groups)].copy()
-
+            
             # plot_data.drop("index", inplace=True, axis=1)
 
             # Assign attributes
@@ -133,7 +133,7 @@ class Dabest(object):
                     err0 = '"{0}" is not a column in `data`.'.format(g)
                     err1 = " Please check `idx` and try again."
                     raise IndexError(err0 + err1)
-
+                    
             set_all_columns     = set(data_in.columns.tolist())
             set_all_plot_groups = set(all_plot_groups)
             id_vars = set_all_columns.difference(set_all_plot_groups)
@@ -143,26 +143,26 @@ class Dabest(object):
                                 value_vars=all_plot_groups,
                                 value_name=self.__yvar,
                                 var_name=self.__xvar)
-
+        
         # Lines 131 to 140 added in v0.2.3.
-        # Fixes a bug that jammed up when the xvar column was already
+        # Fixes a bug that jammed up when the xvar column was already 
         # a pandas Categorical. Now we check for this and act appropriately.
-        if isinstance(plot_data[self.__xvar].dtype,
+        if isinstance(plot_data[self.__xvar].dtype, 
                       pd.CategoricalDtype) is True:
             plot_data[self.__xvar].cat.remove_unused_categories(inplace=True)
-            plot_data[self.__xvar].cat.reorder_categories(all_plot_groups,
-                                                          ordered=True,
+            plot_data[self.__xvar].cat.reorder_categories(all_plot_groups, 
+                                                          ordered=True, 
                                                           inplace=True)
         else:
             plot_data.loc[:, self.__xvar] = pd.Categorical(plot_data[self.__xvar],
                                                categories=all_plot_groups,
                                                ordered=True)
-
+        
         # # The line below was added in v0.2.4, removed in v0.2.5.
         # plot_data.dropna(inplace=True)
-
+        
         self.__plot_data = plot_data
-
+        
         self.__all_plot_groups = all_plot_groups
 
 
@@ -355,7 +355,6 @@ class TwoGroupsEffectSize(object):
 
         """
         Compute the effect size between two groups.
-
         Parameters
         ----------
         control : array-like
@@ -374,47 +373,44 @@ class TwoGroupsEffectSize(object):
             `random_seed` is used to seed the random number generator during
             bootstrap resampling. This ensures that the confidence intervals
             reported are replicable.
-
-
         Returns
         -------
         A :py:class:`TwoGroupEffectSize` object.
-
+        
         difference : float
             The effect size of the difference between the control and the test.
-
+        
         effect_size : string
             The type of effect size reported.
-
+        
         is_paired : boolean
             Whether or not the difference is paired (ie. repeated measures).
-
+            
         ci : float
             Returns the width of the confidence interval, in percent.
-
+            
         alpha : float
             Returns the significance level of the statistical test as a float
             between 0 and 1.
-
+            
         resamples : int
             The number of resamples performed during the bootstrap procedure.
-
         bootstraps : nmupy ndarray
             The generated bootstraps of the effect size.
-
+            
         random_seed : int
             The number used to initialise the numpy random seed generator, ie.
             `seed_value` from `numpy.random.seed(seed_value)` is returned.
-
+            
         bca_low, bca_high : float
             The bias-corrected and accelerated confidence interval lower limit
             and upper limits, respectively.
-
+            
         pct_low, pct_high : float
-            The percentile confidence interval lower limit and upper limits,
+            The percentile confidence interval lower limit and upper limits, 
             respectively.
-
-
+            
+            
         Examples
         --------
         >>> import numpy as np
@@ -428,7 +424,7 @@ class TwoGroupsEffectSize(object):
         The unpaired mean difference is -0.253 [95%CI -0.782, 0.241]
         5000 bootstrap samples. The confidence interval is bias-corrected
         and accelerated.
-        >>> effsize.to_dict()
+        >>> effsize.to_dict() 
         {'alpha': 0.05,
          'bca_high': 0.2413346581369784,
          'bca_interval_idx': (109, 4858),
@@ -630,7 +626,7 @@ class TwoGroupsEffectSize(object):
             # Mann-Whitney test: Non parametric,
             # does not assume normality of distributions
             try:
-                mann_whitney = spstats.mannwhitneyu(control, test,
+                mann_whitney = spstats.mannwhitneyu(control, test, 
                                                     alternative='two-sided')
                 self.__pvalue_mann_whitney = mann_whitney.pvalue
                 self.__statistic_mann_whitney = mann_whitney.statistic
@@ -1013,7 +1009,7 @@ class EffectSizeDataFrame(object):
                 r_dict["test"]      = tname
                 r_dict["control_N"] = int(len(control))
                 r_dict["test_N"]    = int(len(test))
-
+                
                 out.append(r_dict)
 
                 if j == len(idx)-1 and ix == len(current_tuple)-2:
@@ -1094,7 +1090,7 @@ class EffectSizeDataFrame(object):
             swarm_ylim=None, contrast_ylim=None,
 
             custom_palette=None, swarm_desat=0.5, halfviolin_desat=1,
-            halfviolin_alpha=0.8,
+            halfviolin_alpha=0.8, 
 
             float_contrast=True,
             show_pairs=True,
@@ -1113,7 +1109,6 @@ class EffectSizeDataFrame(object):
             legend_kwargs=None):
         """
         Creates an estimation plot for the effect size of interest.
-
         Parameters
         ----------
         color_col : string, default None
@@ -1156,7 +1151,7 @@ class EffectSizeDataFrame(object):
             curves by the desired proportion. Uses `seaborn.desaturate()` to
             acheive this.
         halfviolin_alpha : float, default 0.8
-            The alpha (transparency) level of the half-violin bootstrap curves.
+            The alpha (transparency) level of the half-violin bootstrap curves.            
         float_contrast : boolean, default True
             Whether or not to display the halfviolin bootstrapped difference
             distribution alongside the raw data.
@@ -1172,7 +1167,7 @@ class EffectSizeDataFrame(object):
             instead. If 'None', the summaries are not shown.
         group_summaries_offset : float, default 0.1
             If group summaries are displayed, they will be offset from the raw
-            data swarmplot groups by this value.
+            data swarmplot groups by this value. 
         fig_size : tuple, default None
             The desired dimensions of the figure as a (length, width) tuple.
         dpi : int, default 100
@@ -1206,49 +1201,33 @@ class EffectSizeDataFrame(object):
             `legend` command here, as a dict. If None, the following keywords
             are passed to matplotlib.Axes.legend : {'loc':'upper left',
             'frameon':False}.
-
-
         Returns
         -------
         A :class:`matplotlib.figure.Figure` with 2 Axes.
-
         The first axes (accessible with ``FigName.axes[0]``) contains the rawdata swarmplot; the second axes (accessible with ``FigName.axes[1]``) has the bootstrap distributions and effect sizes (with confidence intervals) plotted on it.
-
         Examples
         --------
         Create a Gardner-Altman estimation plot for the mean difference.
-
         >>> my_data = dabest.load(df, idx=("Control 1", "Test 1"))
         >>> fig1 = my_data.mean_diff.plot()
-
         Create a Gardner-Altman plot for the Hedges' g effect size.
-
         >>> fig2 = my_data.hedges_g.plot()
-
         Create a Cumming estimation plot for the mean difference.
-
         >>> fig3 = my_data.mean_diff.plot(float_contrast=True)
-
         Create a paired Gardner-Altman plot.
-
         >>> my_data_paired = dabest.load(df, idx=("Control 1", "Test 1"),
         ...                              paired=True)
         >>> fig4 = my_data_paired.mean_diff.plot()
-
         Create a multi-group Cumming plot.
-
         >>> my_multi_groups = dabest.load(df, idx=(("Control 1", "Test 1"),
         ...                                        ("Control 2", "Test 2"))
         ...                               )
         >>> fig5 = my_multi_groups.mean_diff.plot()
-
         Create a shared control Cumming plot.
-
         >>> my_shared_control = dabest.load(df, idx=("Control 1", "Test 1",
         ...                                          "Test 2", "Test 3")
         ...                                 )
         >>> fig6 = my_shared_control.mean_diff.plot()
-
         """
 
         from .plotter import EffectSizeDataFramePlotter

--- a/dabest/_classes.py
+++ b/dabest/_classes.py
@@ -355,6 +355,7 @@ class TwoGroupsEffectSize(object):
 
         """
         Compute the effect size between two groups.
+
         Parameters
         ----------
         control : array-like
@@ -373,6 +374,8 @@ class TwoGroupsEffectSize(object):
             `random_seed` is used to seed the random number generator during
             bootstrap resampling. This ensures that the confidence intervals
             reported are replicable.
+
+
         Returns
         -------
         A :py:class:`TwoGroupEffectSize` object.
@@ -395,6 +398,7 @@ class TwoGroupsEffectSize(object):
             
         resamples : int
             The number of resamples performed during the bootstrap procedure.
+
         bootstraps : nmupy ndarray
             The generated bootstraps of the effect size.
             
@@ -1109,6 +1113,7 @@ class EffectSizeDataFrame(object):
             legend_kwargs=None):
         """
         Creates an estimation plot for the effect size of interest.
+
         Parameters
         ----------
         color_col : string, default None
@@ -1201,33 +1206,49 @@ class EffectSizeDataFrame(object):
             `legend` command here, as a dict. If None, the following keywords
             are passed to matplotlib.Axes.legend : {'loc':'upper left',
             'frameon':False}.
+
+
         Returns
         -------
         A :class:`matplotlib.figure.Figure` with 2 Axes.
+
         The first axes (accessible with ``FigName.axes[0]``) contains the rawdata swarmplot; the second axes (accessible with ``FigName.axes[1]``) has the bootstrap distributions and effect sizes (with confidence intervals) plotted on it.
+
         Examples
         --------
         Create a Gardner-Altman estimation plot for the mean difference.
+        
         >>> my_data = dabest.load(df, idx=("Control 1", "Test 1"))
         >>> fig1 = my_data.mean_diff.plot()
+        
         Create a Gardner-Altman plot for the Hedges' g effect size.
+        
         >>> fig2 = my_data.hedges_g.plot()
+        
         Create a Cumming estimation plot for the mean difference.
+        
         >>> fig3 = my_data.mean_diff.plot(float_contrast=True)
+        
         Create a paired Gardner-Altman plot.
+        
         >>> my_data_paired = dabest.load(df, idx=("Control 1", "Test 1"),
         ...                              paired=True)
         >>> fig4 = my_data_paired.mean_diff.plot()
+        
         Create a multi-group Cumming plot.
+        
         >>> my_multi_groups = dabest.load(df, idx=(("Control 1", "Test 1"),
         ...                                        ("Control 2", "Test 2"))
         ...                               )
         >>> fig5 = my_multi_groups.mean_diff.plot()
+        
         Create a shared control Cumming plot.
+        
         >>> my_shared_control = dabest.load(df, idx=("Control 1", "Test 1",
         ...                                          "Test 2", "Test 3")
         ...                                 )
         >>> fig6 = my_shared_control.mean_diff.plot()
+        
         """
 
         from .plotter import EffectSizeDataFramePlotter

--- a/dabest/_classes.py
+++ b/dabest/_classes.py
@@ -44,16 +44,16 @@ class Dabest(object):
             if len(idx) > len(all_plot_groups):
                 err0 = '`idx` contains duplicated groups. Please remove any duplicates and try again.'
                 raise ValueError(err0)
-                
+
             # We need to re-wrap this idx inside another tuple so as to
             # easily loop thru each pairwise group later on.
             self.__idx = (idx,)
 
         elif all([isinstance(i, (tuple, list)) for i in idx]):
             all_plot_groups = pd.unique([tt for t in idx for tt in t]).tolist()
-            
+
             actual_groups_given = sum([len(i) for i in idx])
-            
+
             if actual_groups_given > len(all_plot_groups):
                 err0 = 'Groups are repeated across tuples,'
                 err1 = ' or a tuple has repeated groups in it.'
@@ -107,10 +107,10 @@ class Dabest(object):
                     err1 = " Please check `idx` and try again."
                     raise IndexError(err0 + err1)
 
-            # Select only rows where the value in the `x` column 
+            # Select only rows where the value in the `x` column
             # is found in `idx`.
             plot_data = data_in[data_in.loc[:, x].isin(all_plot_groups)].copy()
-            
+
             # plot_data.drop("index", inplace=True, axis=1)
 
             # Assign attributes
@@ -133,7 +133,7 @@ class Dabest(object):
                     err0 = '"{0}" is not a column in `data`.'.format(g)
                     err1 = " Please check `idx` and try again."
                     raise IndexError(err0 + err1)
-                    
+
             set_all_columns     = set(data_in.columns.tolist())
             set_all_plot_groups = set(all_plot_groups)
             id_vars = set_all_columns.difference(set_all_plot_groups)
@@ -143,26 +143,26 @@ class Dabest(object):
                                 value_vars=all_plot_groups,
                                 value_name=self.__yvar,
                                 var_name=self.__xvar)
-        
+
         # Lines 131 to 140 added in v0.2.3.
-        # Fixes a bug that jammed up when the xvar column was already 
+        # Fixes a bug that jammed up when the xvar column was already
         # a pandas Categorical. Now we check for this and act appropriately.
-        if isinstance(plot_data[self.__xvar].dtype, 
+        if isinstance(plot_data[self.__xvar].dtype,
                       pd.CategoricalDtype) is True:
             plot_data[self.__xvar].cat.remove_unused_categories(inplace=True)
-            plot_data[self.__xvar].cat.reorder_categories(all_plot_groups, 
-                                                          ordered=True, 
+            plot_data[self.__xvar].cat.reorder_categories(all_plot_groups,
+                                                          ordered=True,
                                                           inplace=True)
         else:
             plot_data.loc[:, self.__xvar] = pd.Categorical(plot_data[self.__xvar],
                                                categories=all_plot_groups,
                                                ordered=True)
-        
+
         # # The line below was added in v0.2.4, removed in v0.2.5.
         # plot_data.dropna(inplace=True)
-        
+
         self.__plot_data = plot_data
-        
+
         self.__all_plot_groups = all_plot_groups
 
 
@@ -379,42 +379,42 @@ class TwoGroupsEffectSize(object):
         Returns
         -------
         A :py:class:`TwoGroupEffectSize` object.
-        
+
         difference : float
             The effect size of the difference between the control and the test.
-        
+
         effect_size : string
             The type of effect size reported.
-        
+
         is_paired : boolean
             Whether or not the difference is paired (ie. repeated measures).
-            
+
         ci : float
             Returns the width of the confidence interval, in percent.
-            
+
         alpha : float
             Returns the significance level of the statistical test as a float
             between 0 and 1.
-            
+
         resamples : int
             The number of resamples performed during the bootstrap procedure.
 
         bootstraps : nmupy ndarray
             The generated bootstraps of the effect size.
-            
+
         random_seed : int
             The number used to initialise the numpy random seed generator, ie.
             `seed_value` from `numpy.random.seed(seed_value)` is returned.
-            
+
         bca_low, bca_high : float
             The bias-corrected and accelerated confidence interval lower limit
             and upper limits, respectively.
-            
+
         pct_low, pct_high : float
-            The percentile confidence interval lower limit and upper limits, 
+            The percentile confidence interval lower limit and upper limits,
             respectively.
-            
-            
+
+
         Examples
         --------
         >>> import numpy as np
@@ -428,7 +428,7 @@ class TwoGroupsEffectSize(object):
         The unpaired mean difference is -0.253 [95%CI -0.782, 0.241]
         5000 bootstrap samples. The confidence interval is bias-corrected
         and accelerated.
-        >>> effsize.to_dict() 
+        >>> effsize.to_dict()
         {'alpha': 0.05,
          'bca_high': 0.2413346581369784,
          'bca_interval_idx': (109, 4858),
@@ -630,7 +630,7 @@ class TwoGroupsEffectSize(object):
             # Mann-Whitney test: Non parametric,
             # does not assume normality of distributions
             try:
-                mann_whitney = spstats.mannwhitneyu(control, test, 
+                mann_whitney = spstats.mannwhitneyu(control, test,
                                                     alternative='two-sided')
                 self.__pvalue_mann_whitney = mann_whitney.pvalue
                 self.__statistic_mann_whitney = mann_whitney.statistic
@@ -1013,7 +1013,7 @@ class EffectSizeDataFrame(object):
                 r_dict["test"]      = tname
                 r_dict["control_N"] = int(len(control))
                 r_dict["test_N"]    = int(len(test))
-                
+
                 out.append(r_dict)
 
                 if j == len(idx)-1 and ix == len(current_tuple)-2:
@@ -1094,7 +1094,7 @@ class EffectSizeDataFrame(object):
             swarm_ylim=None, contrast_ylim=None,
 
             custom_palette=None, swarm_desat=0.5, halfviolin_desat=1,
-            halfviolin_alpha=0.8, 
+            halfviolin_alpha=0.8,
 
             float_contrast=True,
             show_pairs=True,
@@ -1103,6 +1103,7 @@ class EffectSizeDataFrame(object):
 
             fig_size=None,
             dpi=100,
+            ax=None,
 
             swarmplot_kwargs=None,
             violinplot_kwargs=None,
@@ -1155,7 +1156,7 @@ class EffectSizeDataFrame(object):
             curves by the desired proportion. Uses `seaborn.desaturate()` to
             acheive this.
         halfviolin_alpha : float, default 0.8
-            The alpha (transparency) level of the half-violin bootstrap curves.            
+            The alpha (transparency) level of the half-violin bootstrap curves.
         float_contrast : boolean, default True
             Whether or not to display the halfviolin bootstrapped difference
             distribution alongside the raw data.
@@ -1171,11 +1172,14 @@ class EffectSizeDataFrame(object):
             instead. If 'None', the summaries are not shown.
         group_summaries_offset : float, default 0.1
             If group summaries are displayed, they will be offset from the raw
-            data swarmplot groups by this value. 
+            data swarmplot groups by this value.
         fig_size : tuple, default None
             The desired dimensions of the figure as a (length, width) tuple.
         dpi : int, default 100
             The dots per inch of the resulting figure.
+        ax : matplotlib.Axes, default None
+            Provide an existing axes for the plots to be created. If no axes
+            specified, a new figure will be created with the plot.
         swarmplot_kwargs : dict, default None
             Pass any keyword arguments accepted by the seaborn `swarmplot`
             command here, as a dict. If None, the following keywords are

--- a/dabest/_classes.py
+++ b/dabest/_classes.py
@@ -1217,38 +1217,38 @@ class EffectSizeDataFrame(object):
         Examples
         --------
         Create a Gardner-Altman estimation plot for the mean difference.
-        
+
         >>> my_data = dabest.load(df, idx=("Control 1", "Test 1"))
         >>> fig1 = my_data.mean_diff.plot()
-        
+
         Create a Gardner-Altman plot for the Hedges' g effect size.
-        
+
         >>> fig2 = my_data.hedges_g.plot()
-        
+
         Create a Cumming estimation plot for the mean difference.
-        
+
         >>> fig3 = my_data.mean_diff.plot(float_contrast=True)
-        
+
         Create a paired Gardner-Altman plot.
-        
+
         >>> my_data_paired = dabest.load(df, idx=("Control 1", "Test 1"),
         ...                              paired=True)
         >>> fig4 = my_data_paired.mean_diff.plot()
-        
+
         Create a multi-group Cumming plot.
-        
+
         >>> my_multi_groups = dabest.load(df, idx=(("Control 1", "Test 1"),
         ...                                        ("Control 2", "Test 2"))
         ...                               )
         >>> fig5 = my_multi_groups.mean_diff.plot()
-        
+
         Create a shared control Cumming plot.
-        
+
         >>> my_shared_control = dabest.load(df, idx=("Control 1", "Test 1",
         ...                                          "Test 2", "Test 3")
         ...                                 )
         >>> fig6 = my_shared_control.mean_diff.plot()
-        
+
         """
 
         from .plotter import EffectSizeDataFramePlotter

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -31,6 +31,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
 
         fig_size=None,
         dpi=100,
+        ax=None,
 
         swarmplot_kwargs=None,
         violinplot_kwargs=None,
@@ -256,38 +257,64 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     # sns.set(context="talk", style='ticks')
     init_fig_kwargs = dict(figsize=fig_size, dpi=plot_kwargs["dpi"])
 
-    # TODO: implement check for user input axes instead of new fig
-    # Here, we hardcode some figure parameters.
-    if float_contrast is True:
-#        fig, axx = plt.subplots(ncols=2,
-#                                gridspec_kw={"width_ratios": [2.5, 1],
-#                                             "wspace": 0},
-#                                **init_fig_kwargs)
-        fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
-        axins = rawdata_axes.inset_axes([1, 0, 0.4, 1])
-        rawdata_axes.set_position([0.125, 0.125, 0.55, 0.75])
+    # TODO: double check that everything is working!
+    if plot_kwargs["ax"] is not None:
+        ax = plot_kwargs["ax"]
+        fig = ax.get_figure()
+        ax_position = ax.get_position()  # [[x0, y0], [x1, y1]]
+        rawdata_axes = ax
+        if float_contrast is True:
+
+#            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
+            axins = rawdata_axes.inset_axes([1, 0, 0.4, 1])
+#            rawdata_axes.set_position([0.125, 0.125, 0.55, 0.75])
+            rawdata_axes.set_position( # [l, b, w, h]
+                    [ax_position.x0,
+                     ax_position.y0,
+                     (ax_position.x1 - ax_position.x0) * 0.55,
+                     (ax_position.y1 - ax_position.y0) * 0.75])
+
+            contrast_axes = axins
+
+        else:
+#            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
+            axins = rawdata_axes.inset_axes([0, -1.3, 1, 1])
+#            rawdata_axes.set_position([0.125, 0.55, 0.775, 0.33])
+            rawdata_axes.set_position(
+                    [ax_position.x0,
+                     ax_position.y0 + 0.55 * (ax_position.y1 - ax_position.y0),
+                     (ax_position.x1 - ax_position.x0), #  * 0.775,
+                     (ax_position.y1 - ax_position.y0) * 0.33])
+
+    #        Bbox(x0=0.125, y0=0.12499999999999989, x1=0.9, y1=0.45326086956521733)
+
+            # If the contrast axes are NOT floating, create lists to store raw ylims
+            # and raw tick intervals, so that I can normalize their ylims later.
+            contrast_ax_ylim_low = list()
+            contrast_ax_ylim_high = list()
+            contrast_ax_ylim_tickintervals = list()
         contrast_axes = axins
 
     else:
-#        fig, axx = plt.subplots(nrows=2,
-#                                gridspec_kw={"hspace": 0.3},
-#                                **init_fig_kwargs)
-        fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
-        axins = rawdata_axes.inset_axes([0, -1.3, 1, 1])
-        rawdata_axes.set_position([0.125, 0.55, 0.775, 0.33])
-        contrast_axes = axins
-#        Bbox(x0=0.125, y0=0.12499999999999989, x1=0.9, y1=0.45326086956521733)
+        # Here, we hardcode some figure parameters.
+        if float_contrast is True:
+            fig, axx = plt.subplots(ncols=2,
+                                    gridspec_kw={"width_ratios": [2.5, 1],
+                                                 "wspace": 0},
+                                    **init_fig_kwargs)
 
-        # If the contrast axes are NOT floating, create lists to store raw ylims
-        # and raw tick intervals, so that I can normalize their ylims later.
-        contrast_ax_ylim_low = list()
-        contrast_ax_ylim_high = list()
-        contrast_ax_ylim_tickintervals = list()
-#        rawdata_axes  = axx[0]
-#        contrast_axes = axx[1]
+        else:
+            fig, axx = plt.subplots(nrows=2,
+                                    gridspec_kw={"hspace": 0.3},
+                                    **init_fig_kwargs)
+            # If the contrast axes are NOT floating, create lists to store raw ylims
+            # and raw tick intervals, so that I can normalize their ylims later.
+            contrast_ax_ylim_low = list()
+            contrast_ax_ylim_high = list()
+            contrast_ax_ylim_tickintervals = list()
 
-#    rawdata_axes  = axx[0]
-#    contrast_axes = axx[1]
+        rawdata_axes  = axx[0]
+        contrast_axes = axx[1]
 
     rawdata_axes.set_frame_on(False)
     contrast_axes.set_frame_on(False)

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -256,32 +256,35 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     # sns.set(context="talk", style='ticks')
     init_fig_kwargs = dict(figsize=fig_size, dpi=plot_kwargs["dpi"])
 
+    # TODO: implement check for user input axes instead of new fig
     # Here, we hardcode some figure parameters.
     if float_contrast is True:
 #        fig, axx = plt.subplots(ncols=2,
 #                                gridspec_kw={"width_ratios": [2.5, 1],
 #                                             "wspace": 0},
 #                                **init_fig_kwargs)
-        #  Bbox(x0=0.125, y0=0.125, x1=0.6785714285714286, y1=0.88)
         fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
         axins = rawdata_axes.inset_axes([1, 0, 0.4, 1])
         rawdata_axes.set_position([0.125, 0.125, 0.55, 0.75])
         contrast_axes = axins
-        # TODO: implement check for user input axes instead of new fig
 
     else:
-        fig, axx = plt.subplots(nrows=2,
-                                gridspec_kw={"hspace": 0.3},
-                                **init_fig_kwargs)
+#        fig, axx = plt.subplots(nrows=2,
+#                                gridspec_kw={"hspace": 0.3},
+#                                **init_fig_kwargs)
+        fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
+        axins = rawdata_axes.inset_axes([0, -1.3, 1, 1])
+        rawdata_axes.set_position([0.125, 0.55, 0.775, 0.33])
+        contrast_axes = axins
+#        Bbox(x0=0.125, y0=0.12499999999999989, x1=0.9, y1=0.45326086956521733)
 
         # If the contrast axes are NOT floating, create lists to store raw ylims
         # and raw tick intervals, so that I can normalize their ylims later.
         contrast_ax_ylim_low = list()
         contrast_ax_ylim_high = list()
         contrast_ax_ylim_tickintervals = list()
-        rawdata_axes  = axx[0]
-        contrast_axes = axx[1]
-        # TODO: implement inset axes for plots with two rows
+#        rawdata_axes  = axx[0]
+#        contrast_axes = axx[1]
 
 #    rawdata_axes  = axx[0]
 #    contrast_axes = axx[1]
@@ -410,6 +413,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     # Take note of where the `control` groups are.
     ticks_to_skip   = np.cumsum([len(t) for t in idx])[:-1].tolist()
     ticks_to_skip.insert(0, 0)
+    # TODO: fix x-axis skip bug in inset axes
 
     # Then obtain the ticks where we have to plot the effect sizes.
     ticks_to_plot = [t for t in range(0, len(all_plot_groups))

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -22,7 +22,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         swarm_ylim=None, contrast_ylim=None,
 
         custom_palette=None, swarm_desat=0.5, halfviolin_desat=1,
-        halfviolin_alpha=0.8,
+        halfviolin_alpha=0.8, 
 
         float_contrast=True,
         show_pairs=True,
@@ -257,7 +257,6 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     # sns.set(context="talk", style='ticks')
     init_fig_kwargs = dict(figsize=fig_size, dpi=plot_kwargs["dpi"])
 
-    # TODO: double check that everything is working!
     width_ratios_ga = [2.5, 1]
     h_scpace_cummings = 0.3
     if plot_kwargs["ax"] is not None:
@@ -266,24 +265,20 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         ax_position = ax.get_position()  # [[x0, y0], [x1, y1]]
         rawdata_axes = ax
         if float_contrast is True:
-
-#            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
             axins = rawdata_axes.inset_axes(
                     [1, 0,
                      width_ratios_ga[1]/width_ratios_ga[0], 1])
-            rawdata_axes.set_position( # [l, b, w, h]
+            rawdata_axes.set_position(  # [l, b, w, h]
                     [ax_position.x0,
                      ax_position.y0,
-                     (ax_position.x1 - ax_position.x0)*(width_ratios_ga[0]/
-                                                        sum(width_ratios_ga)),
+                     (ax_position.x1 - ax_position.x0) * (width_ratios_ga[0] /
+                                                         sum(width_ratios_ga)),
                      (ax_position.y1 - ax_position.y0)])
 
             contrast_axes = axins
 
         else:
-#            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
             axins = rawdata_axes.inset_axes([0, -1 - h_scpace_cummings, 1, 1])
-#            rawdata_axes.set_position([0.125, 0.55, 0.775, 0.33])
             plot_height = ((ax_position.y1 - ax_position.y0) /
                            (2 + h_scpace_cummings))
             rawdata_axes.set_position(
@@ -568,7 +563,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         _, contrast_xlim_max = contrast_axes.get_xlim()
 
         difference = float(results.difference[0])
-
+        
         if effect_size_type in ["mean_diff", "median_diff"]:
             # Align 0 of contrast_axes to reference group mean of rawdata_axes.
             # If the effect size is positive, shift the contrast axis up.
@@ -595,25 +590,25 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
                 which_std = 0
             temp_control = plot_data[plot_data[xvar] == current_control][yvar]
             temp_test    = plot_data[plot_data[xvar] == current_group][yvar]
-
+            
             stds = _compute_standardizers(temp_control, temp_test)
             if is_paired:
                 pooled_sd = stds[1]
             else:
                 pooled_sd = stds[0]
-
+            
             if effect_size_type == 'hedges_g':
                 gby_count   = plot_data.groupby(xvar).count()
                 len_control = gby_count.loc[current_control, yvar]
                 len_test    = gby_count.loc[current_group, yvar]
-
+                            
                 hg_correction_factor = _compute_hedges_correction_factor(len_control, len_test)
-
+                            
                 ylim_scale_factor = pooled_sd / hg_correction_factor
-
+                
             else:
                 ylim_scale_factor = pooled_sd
-
+                
             scaled_ylim = ((rawdata_axes.get_ylim() - control_group_summary) / ylim_scale_factor).tolist()
 
             contrast_axes.set_ylim(scaled_ylim)
@@ -643,7 +638,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
             axx.hlines(ref,            # y-coordinates
                        0, xlimhigh,  # x-coordinates, start and end.
                        **reflines_kwargs)
-
+                        
             # Draw effect size line.
             axx.hlines(diff, effsize_line_start, xlimhigh,
                        **reflines_kwargs)
@@ -699,7 +694,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         # Compute the end of each x-axes line.
         rightend_ticks = np.array([len(i)-1 for i in idx]) + np.array(ticks_to_skip)
 
-        for ax in [rawdata_axes, contrast_axes]:
+        for ax in fig.axes:
             sns.despine(ax=ax, bottom=True)
 
             ylim = ax.get_ylim()
@@ -723,7 +718,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         swarm_label = "value"
     elif swarm_label is None and yvar is not None:
         swarm_label = yvar
-
+        
     # Place contrast axes y-label.
     contrast_label_dict = {'mean_diff'    : "mean difference",
                            'median_diff'  : "median difference",
@@ -746,7 +741,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         contrast_axes.yaxis.set_label_position("right")
 
 
-    # Set the rawdata axes labels appropriately
+    # Set the rawdata axes labels appropriately        
     rawdata_axes.set_ylabel(swarm_label)
     rawdata_axes.set_xlabel("")
 

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -22,7 +22,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         swarm_ylim=None, contrast_ylim=None,
 
         custom_palette=None, swarm_desat=0.5, halfviolin_desat=1,
-        halfviolin_alpha=0.8, 
+        halfviolin_alpha=0.8,
 
         float_contrast=True,
         show_pairs=True,
@@ -258,10 +258,16 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
 
     # Here, we hardcode some figure parameters.
     if float_contrast is True:
-        fig, axx = plt.subplots(ncols=2,
-                                gridspec_kw={"width_ratios": [2.5, 1],
-                                             "wspace": 0},
-                                **init_fig_kwargs)
+#        fig, axx = plt.subplots(ncols=2,
+#                                gridspec_kw={"width_ratios": [2.5, 1],
+#                                             "wspace": 0},
+#                                **init_fig_kwargs)
+        #  Bbox(x0=0.125, y0=0.125, x1=0.6785714285714286, y1=0.88)
+        fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
+        axins = rawdata_axes.inset_axes([1, 0, 0.4, 1])
+        rawdata_axes.set_position([0.125, 0.125, 0.55, 0.75])
+        contrast_axes = axins
+        # TODO: implement check for user input axes instead of new fig
 
     else:
         fig, axx = plt.subplots(nrows=2,
@@ -273,9 +279,12 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         contrast_ax_ylim_low = list()
         contrast_ax_ylim_high = list()
         contrast_ax_ylim_tickintervals = list()
+        rawdata_axes  = axx[0]
+        contrast_axes = axx[1]
+        # TODO: implement inset axes for plots with two rows
 
-    rawdata_axes  = axx[0]
-    contrast_axes = axx[1]
+#    rawdata_axes  = axx[0]
+#    contrast_axes = axx[1]
 
     rawdata_axes.set_frame_on(False)
     contrast_axes.set_frame_on(False)
@@ -521,7 +530,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         _, contrast_xlim_max = contrast_axes.get_xlim()
 
         difference = float(results.difference[0])
-        
+
         if effect_size_type in ["mean_diff", "median_diff"]:
             # Align 0 of contrast_axes to reference group mean of rawdata_axes.
             # If the effect size is positive, shift the contrast axis up.
@@ -548,25 +557,25 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
                 which_std = 0
             temp_control = plot_data[plot_data[xvar] == current_control][yvar]
             temp_test    = plot_data[plot_data[xvar] == current_group][yvar]
-            
+
             stds = _compute_standardizers(temp_control, temp_test)
             if is_paired:
                 pooled_sd = stds[1]
             else:
                 pooled_sd = stds[0]
-            
+
             if effect_size_type == 'hedges_g':
                 gby_count   = plot_data.groupby(xvar).count()
                 len_control = gby_count.loc[current_control, yvar]
                 len_test    = gby_count.loc[current_group, yvar]
-                            
+
                 hg_correction_factor = _compute_hedges_correction_factor(len_control, len_test)
-                            
+
                 ylim_scale_factor = pooled_sd / hg_correction_factor
-                
+
             else:
                 ylim_scale_factor = pooled_sd
-                
+
             scaled_ylim = ((rawdata_axes.get_ylim() - control_group_summary) / ylim_scale_factor).tolist()
 
             contrast_axes.set_ylim(scaled_ylim)
@@ -596,7 +605,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
             axx.hlines(ref,            # y-coordinates
                        0, xlimhigh,  # x-coordinates, start and end.
                        **reflines_kwargs)
-                        
+
             # Draw effect size line.
             axx.hlines(diff, effsize_line_start, xlimhigh,
                        **reflines_kwargs)
@@ -676,7 +685,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         swarm_label = "value"
     elif swarm_label is None and yvar is not None:
         swarm_label = yvar
-        
+
     # Place contrast axes y-label.
     contrast_label_dict = {'mean_diff'    : "mean difference",
                            'median_diff'  : "median difference",
@@ -699,7 +708,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         contrast_axes.yaxis.set_label_position("right")
 
 
-    # Set the rawdata axes labels appropriately        
+    # Set the rawdata axes labels appropriately
     rawdata_axes.set_ylabel(swarm_label)
     rawdata_axes.set_xlabel("")
 

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -258,6 +258,8 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     init_fig_kwargs = dict(figsize=fig_size, dpi=plot_kwargs["dpi"])
 
     # TODO: double check that everything is working!
+    width_ratios_ga = [2.5, 1]
+    h_scpace_cummings = 0.3
     if plot_kwargs["ax"] is not None:
         ax = plot_kwargs["ax"]
         fig = ax.get_figure()
@@ -266,49 +268,55 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         if float_contrast is True:
 
 #            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
-            axins = rawdata_axes.inset_axes([1, 0, 0.4, 1])
-#            rawdata_axes.set_position([0.125, 0.125, 0.55, 0.75])
+            axins = rawdata_axes.inset_axes(
+                    [1, 0,
+                     width_ratios_ga[1]/width_ratios_ga[0], 1])
             rawdata_axes.set_position( # [l, b, w, h]
                     [ax_position.x0,
                      ax_position.y0,
-                     (ax_position.x1 - ax_position.x0) * 0.55,
-                     (ax_position.y1 - ax_position.y0) * 0.75])
+                     (ax_position.x1 - ax_position.x0)*(width_ratios_ga[0]/
+                                                        sum(width_ratios_ga)),
+                     (ax_position.y1 - ax_position.y0)])
 
             contrast_axes = axins
 
         else:
 #            fig, rawdata_axes = plt.subplots(**init_fig_kwargs)
-            axins = rawdata_axes.inset_axes([0, -1.3, 1, 1])
+            axins = rawdata_axes.inset_axes([0, -1 - h_scpace_cummings, 1, 1])
 #            rawdata_axes.set_position([0.125, 0.55, 0.775, 0.33])
+            plot_height = ((ax_position.y1 - ax_position.y0) /
+                           (2 + h_scpace_cummings))
             rawdata_axes.set_position(
                     [ax_position.x0,
-                     ax_position.y0 + 0.55 * (ax_position.y1 - ax_position.y0),
-                     (ax_position.x1 - ax_position.x0), #  * 0.775,
-                     (ax_position.y1 - ax_position.y0) * 0.33])
+                     ax_position.y0 + (1 + h_scpace_cummings) * plot_height,
+                     (ax_position.x1 - ax_position.x0),
+                     plot_height])
 
-    #        Bbox(x0=0.125, y0=0.12499999999999989, x1=0.9, y1=0.45326086956521733)
-
-            # If the contrast axes are NOT floating, create lists to store raw ylims
-            # and raw tick intervals, so that I can normalize their ylims later.
+            # If the contrast axes are NOT floating, create lists to store
+            # raw ylims and raw tick intervals, so that I can normalize
+            # their ylims later.
             contrast_ax_ylim_low = list()
             contrast_ax_ylim_high = list()
             contrast_ax_ylim_tickintervals = list()
         contrast_axes = axins
+        ax.contrast_axes = axins
 
     else:
         # Here, we hardcode some figure parameters.
         if float_contrast is True:
-            fig, axx = plt.subplots(ncols=2,
-                                    gridspec_kw={"width_ratios": [2.5, 1],
-                                                 "wspace": 0},
-                                    **init_fig_kwargs)
+            fig, axx = plt.subplots(
+                    ncols=2,
+                    gridspec_kw={"width_ratios": width_ratios_ga,
+                                 "wspace": 0},
+                                 **init_fig_kwargs)
 
         else:
             fig, axx = plt.subplots(nrows=2,
                                     gridspec_kw={"hspace": 0.3},
                                     **init_fig_kwargs)
-            # If the contrast axes are NOT floating, create lists to store raw ylims
-            # and raw tick intervals, so that I can normalize their ylims later.
+            # If the contrast axes are NOT floating, create lists to store
+            # raw ylims and raw tick intervals, so that I can normalize
+            # their ylims later.
             contrast_ax_ylim_low = list()
             contrast_ax_ylim_high = list()
             contrast_ax_ylim_tickintervals = list()
@@ -440,7 +448,6 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     # Take note of where the `control` groups are.
     ticks_to_skip   = np.cumsum([len(t) for t in idx])[:-1].tolist()
     ticks_to_skip.insert(0, 0)
-    # TODO: fix x-axis skip bug in inset axes
 
     # Then obtain the ticks where we have to plot the effect sizes.
     ticks_to_plot = [t for t in range(0, len(all_plot_groups))
@@ -692,7 +699,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         # Compute the end of each x-axes line.
         rightend_ticks = np.array([len(i)-1 for i in idx]) + np.array(ticks_to_skip)
 
-        for ax in fig.axes:
+        for ax in [rawdata_axes, contrast_axes]:
             sns.despine(ax=ax, bottom=True)
 
             ylim = ax.get_ylim()

--- a/dabest/tests/test_04_inset_plots.py
+++ b/dabest/tests/test_04_inset_plots.py
@@ -8,18 +8,16 @@ Created on Thu Sep 26 16:57:11 2019
 
 import pytest
 import matplotlib as mpl
-import matplotlib.pyplot as plt
-mpl.use('Agg')
 
 import numpy as np
-import scipy as sp
-import pandas as pd
 import seaborn as sns
 from .._api import load
 from .utils import create_dummy_dataset, get_swarm_yspans
+import matplotlib.pyplot as plt
+mpl.use('Agg')
 
 
-def test_gardner_altman_unpaired():
+def test_gardner_altman_inset_plot():
 
     base_mean = np.random.randint(10, 101)
     seed, ptp, df = create_dummy_dataset(base_mean=base_mean)
@@ -28,21 +26,22 @@ def test_gardner_altman_unpaired():
     for c in df.columns[1:-1]:
         print('{}...'.format(c))
 
-        # Create Gardner-Altman plot.
+        # Create Gardner-Altman plot with specified axes
+        f1, ax = plt.subplots(1)
         rand_swarm_ylim = (np.random.uniform(base_mean-10, base_mean, 1),
                            np.random.uniform(base_mean, base_mean+10, 1))
         two_group_unpaired = load(df, idx=(df.columns[0], c))
         f1 = two_group_unpaired.mean_diff.plot(swarm_ylim=rand_swarm_ylim,
                                                swarm_label="Raw swarmplot...",
-                                               contrast_label="Contrast!")
+                                               contrast_label="Contrast!",
+                                               ax=ax)
 
-        rawswarm_axes = f1.axes[0]
-        contrast_axes = f1.axes[1]
+        rawswarm_axes = ax
+        contrast_axes = ax.contrast_axes
 
         # Check ylims match the desired ones.
         assert rawswarm_axes.get_ylim()[0] == pytest.approx(rand_swarm_ylim[0])
         assert rawswarm_axes.get_ylim()[1] == pytest.approx(rand_swarm_ylim[1])
-
 
         # Check each swarmplot group matches canonical seaborn swarmplot.
         _, swarmplt = plt.subplots(1)
@@ -52,7 +51,7 @@ def test_gardner_altman_unpaired():
         for coll in swarmplt.collections:
             sns_yspans.append(get_swarm_yspans(coll))
         dabest_yspans = [get_swarm_yspans(coll)
-                        for coll in rawswarm_axes.collections]
+                         for coll in rawswarm_axes.collections]
         for j, span in enumerate(sns_yspans):
             assert span == pytest.approx(dabest_yspans[j])
 
@@ -61,7 +60,8 @@ def test_gardner_altman_unpaired():
         assert swarm_xticks[0] == "{}\nN = 30".format(df.columns[0])
         assert swarm_xticks[1] == "{}\nN = 30".format(c)
 
-        contrast_xticks = [a.get_text() for a in contrast_axes.get_xticklabels()]
+        contrast_xticks = [a.get_text()
+                           for a in contrast_axes.get_xticklabels()]
         assert contrast_xticks[1] == "{}\nminus\n{}".format(c, df.columns[0])
 
         # Check ylabels.
@@ -72,75 +72,75 @@ def test_gardner_altman_unpaired():
 
 
 
-def test_cummings_unpaired():
-    base_mean = np.random.randint(-5, 5)
-    seed, ptp, df = create_dummy_dataset(base_mean=base_mean, expt_groups=7)
-    print('\nSeed = {}; base mean = {}'.format(seed, base_mean))
-
-    IDX = (('0','5'), ('3','2'), ('4', '1', '6'))
-    multi_2group_unpaired = load(df, idx=IDX)
-
-    rand_swarm_ylim = (np.random.uniform(base_mean-10, base_mean, 1),
-                       np.random.uniform(base_mean, base_mean+10, 1))
-
-    if base_mean == 0:
-        # Have to set the contrast ylim, because the way I dynamically generate
-        # the contrast ylims will flunk out with base_mean = 0.
-        rand_contrast_ylim = (-0.5, 0.5)
-    else:
-        rand_contrast_ylim = (-base_mean/3, base_mean/3)
-
-    f1 = multi_2group_unpaired.mean_diff.plot(swarm_ylim=rand_swarm_ylim,
-                                              contrast_ylim=rand_contrast_ylim,
-                                              swarm_label="Raw swarmplot!",
-                                              contrast_label="Contrast...")
-
-    rawswarm_axes = f1.axes[0]
-    contrast_axes = f1.axes[1]
-
-    # Check swarm ylims match the desired ones.
-    assert rawswarm_axes.get_ylim()[0] == pytest.approx(rand_swarm_ylim[0])
-    assert rawswarm_axes.get_ylim()[1] == pytest.approx(rand_swarm_ylim[1])
-
-    # Check contrast ylims match the desired ones.
-    assert contrast_axes.get_ylim()[0] == pytest.approx(rand_contrast_ylim[0])
-    assert contrast_axes.get_ylim()[1] == pytest.approx(rand_contrast_ylim[1])
-
-    # Check xtick labels.
-    idx_flat = [g for t in IDX for g in t]
-    swarm_xticks = [a.get_text() for a in rawswarm_axes.get_xticklabels()]
-    for j, xtick in enumerate(swarm_xticks):
-        assert xtick == "{}\nN = 30".format(idx_flat[j])
-
-    contrast_xticks = [a.get_text() for a in contrast_axes.get_xticklabels()]
-    assert contrast_xticks[1] == "5\nminus\n0"
-    assert contrast_xticks[3] == "2\nminus\n3"
-    assert contrast_xticks[5] == "1\nminus\n4"
-    assert contrast_xticks[6] == "6\nminus\n4"
-
-    # Check ylabels.
-    assert rawswarm_axes.get_ylabel() == "Raw swarmplot!"
-    assert contrast_axes.get_ylabel() == "Contrast..."
-
-
-
-
-
-def test_gardner_altman_paired():
-    base_mean = np.random.randint(-5, 5)
-    seed, ptp, df = create_dummy_dataset(base_mean=base_mean)
-
-
-    # Check that the plot data matches the raw data.
-    two_group_paired = load(df, idx=("1", "2"), id_col="idcol", paired=True)
-    f1 = two_group_paired.mean_diff.plot()
-    rawswarm_axes = f1.axes[0]
-    contrast_axes = f1.axes[1]
-    assert df['1'].tolist() == [l.get_ydata()[0] for l in rawswarm_axes.lines]
-    assert df['2'].tolist() == [l.get_ydata()[1] for l in rawswarm_axes.lines]
-
-
-    # Check that id_col must be specified.
-    err_to_catch = "`id_col` must be specified if `is_paired` is set to True."
-    with pytest.raises(IndexError, match=err_to_catch):
-        this_will_not_work = load(df, idx=("1", "2"), paired=True)
+#def test_cummings_unpaired():
+#    base_mean = np.random.randint(-5, 5)
+#    seed, ptp, df = create_dummy_dataset(base_mean=base_mean, expt_groups=7)
+#    print('\nSeed = {}; base mean = {}'.format(seed, base_mean))
+#
+#    IDX = (('0','5'), ('3','2'), ('4', '1', '6'))
+#    multi_2group_unpaired = load(df, idx=IDX)
+#
+#    rand_swarm_ylim = (np.random.uniform(base_mean-10, base_mean, 1),
+#                       np.random.uniform(base_mean, base_mean+10, 1))
+#
+#    if base_mean == 0:
+#        # Have to set the contrast ylim, because the way I dynamically generate
+#        # the contrast ylims will flunk out with base_mean = 0.
+#        rand_contrast_ylim = (-0.5, 0.5)
+#    else:
+#        rand_contrast_ylim = (-base_mean/3, base_mean/3)
+#
+#    f1 = multi_2group_unpaired.mean_diff.plot(swarm_ylim=rand_swarm_ylim,
+#                                              contrast_ylim=rand_contrast_ylim,
+#                                              swarm_label="Raw swarmplot!",
+#                                              contrast_label="Contrast...")
+#
+#    rawswarm_axes = f1.axes[0]
+#    contrast_axes = f1.axes[1]
+#
+#    # Check swarm ylims match the desired ones.
+#    assert rawswarm_axes.get_ylim()[0] == pytest.approx(rand_swarm_ylim[0])
+#    assert rawswarm_axes.get_ylim()[1] == pytest.approx(rand_swarm_ylim[1])
+#
+#    # Check contrast ylims match the desired ones.
+#    assert contrast_axes.get_ylim()[0] == pytest.approx(rand_contrast_ylim[0])
+#    assert contrast_axes.get_ylim()[1] == pytest.approx(rand_contrast_ylim[1])
+#
+#    # Check xtick labels.
+#    idx_flat = [g for t in IDX for g in t]
+#    swarm_xticks = [a.get_text() for a in rawswarm_axes.get_xticklabels()]
+#    for j, xtick in enumerate(swarm_xticks):
+#        assert xtick == "{}\nN = 30".format(idx_flat[j])
+#
+#    contrast_xticks = [a.get_text() for a in contrast_axes.get_xticklabels()]
+#    assert contrast_xticks[1] == "5\nminus\n0"
+#    assert contrast_xticks[3] == "2\nminus\n3"
+#    assert contrast_xticks[5] == "1\nminus\n4"
+#    assert contrast_xticks[6] == "6\nminus\n4"
+#
+#    # Check ylabels.
+#    assert rawswarm_axes.get_ylabel() == "Raw swarmplot!"
+#    assert contrast_axes.get_ylabel() == "Contrast..."
+#
+#
+#
+#
+#
+#def test_gardner_altman_paired():
+#    base_mean = np.random.randint(-5, 5)
+#    seed, ptp, df = create_dummy_dataset(base_mean=base_mean)
+#
+#
+#    # Check that the plot data matches the raw data.
+#    two_group_paired = load(df, idx=("1", "2"), id_col="idcol", paired=True)
+#    f1 = two_group_paired.mean_diff.plot()
+#    rawswarm_axes = f1.axes[0]
+#    contrast_axes = f1.axes[1]
+#    assert df['1'].tolist() == [l.get_ydata()[0] for l in rawswarm_axes.lines]
+#    assert df['2'].tolist() == [l.get_ydata()[1] for l in rawswarm_axes.lines]
+#
+#
+#    # Check that id_col must be specified.
+#    err_to_catch = "`id_col` must be specified if `is_paired` is set to True."
+#    with pytest.raises(IndexError, match=err_to_catch):
+#        this_will_not_work = load(df, idx=("1", "2"), paired=True)

--- a/dabest/tests/test_04_inset_plots.py
+++ b/dabest/tests/test_04_inset_plots.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Sep 26 16:57:11 2019
+
+@author: adam nekimken
+"""
+
+import pytest
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+mpl.use('Agg')
+
+import numpy as np
+import scipy as sp
+import pandas as pd
+import seaborn as sns
+from .._api import load
+from .utils import create_dummy_dataset, get_swarm_yspans
+
+
+def test_gardner_altman_unpaired():
+
+    base_mean = np.random.randint(10, 101)
+    seed, ptp, df = create_dummy_dataset(base_mean=base_mean)
+    print('\nSeed = {}; base mean = {}'.format(seed, base_mean))
+
+    for c in df.columns[1:-1]:
+        print('{}...'.format(c))
+
+        # Create Gardner-Altman plot.
+        rand_swarm_ylim = (np.random.uniform(base_mean-10, base_mean, 1),
+                           np.random.uniform(base_mean, base_mean+10, 1))
+        two_group_unpaired = load(df, idx=(df.columns[0], c))
+        f1 = two_group_unpaired.mean_diff.plot(swarm_ylim=rand_swarm_ylim,
+                                               swarm_label="Raw swarmplot...",
+                                               contrast_label="Contrast!")
+
+        rawswarm_axes = f1.axes[0]
+        contrast_axes = f1.axes[1]
+
+        # Check ylims match the desired ones.
+        assert rawswarm_axes.get_ylim()[0] == pytest.approx(rand_swarm_ylim[0])
+        assert rawswarm_axes.get_ylim()[1] == pytest.approx(rand_swarm_ylim[1])
+
+
+        # Check each swarmplot group matches canonical seaborn swarmplot.
+        _, swarmplt = plt.subplots(1)
+        swarmplt.set_ylim(rand_swarm_ylim)
+        sns.swarmplot(data=df[[df.columns[0], c]], ax=swarmplt)
+        sns_yspans = []
+        for coll in swarmplt.collections:
+            sns_yspans.append(get_swarm_yspans(coll))
+        dabest_yspans = [get_swarm_yspans(coll)
+                        for coll in rawswarm_axes.collections]
+        for j, span in enumerate(sns_yspans):
+            assert span == pytest.approx(dabest_yspans[j])
+
+        # Check xtick labels.
+        swarm_xticks = [a.get_text() for a in rawswarm_axes.get_xticklabels()]
+        assert swarm_xticks[0] == "{}\nN = 30".format(df.columns[0])
+        assert swarm_xticks[1] == "{}\nN = 30".format(c)
+
+        contrast_xticks = [a.get_text() for a in contrast_axes.get_xticklabels()]
+        assert contrast_xticks[1] == "{}\nminus\n{}".format(c, df.columns[0])
+
+        # Check ylabels.
+        assert rawswarm_axes.get_ylabel() == "Raw swarmplot..."
+        assert contrast_axes.get_ylabel() == "Contrast!"
+
+
+
+
+
+def test_cummings_unpaired():
+    base_mean = np.random.randint(-5, 5)
+    seed, ptp, df = create_dummy_dataset(base_mean=base_mean, expt_groups=7)
+    print('\nSeed = {}; base mean = {}'.format(seed, base_mean))
+
+    IDX = (('0','5'), ('3','2'), ('4', '1', '6'))
+    multi_2group_unpaired = load(df, idx=IDX)
+
+    rand_swarm_ylim = (np.random.uniform(base_mean-10, base_mean, 1),
+                       np.random.uniform(base_mean, base_mean+10, 1))
+
+    if base_mean == 0:
+        # Have to set the contrast ylim, because the way I dynamically generate
+        # the contrast ylims will flunk out with base_mean = 0.
+        rand_contrast_ylim = (-0.5, 0.5)
+    else:
+        rand_contrast_ylim = (-base_mean/3, base_mean/3)
+
+    f1 = multi_2group_unpaired.mean_diff.plot(swarm_ylim=rand_swarm_ylim,
+                                              contrast_ylim=rand_contrast_ylim,
+                                              swarm_label="Raw swarmplot!",
+                                              contrast_label="Contrast...")
+
+    rawswarm_axes = f1.axes[0]
+    contrast_axes = f1.axes[1]
+
+    # Check swarm ylims match the desired ones.
+    assert rawswarm_axes.get_ylim()[0] == pytest.approx(rand_swarm_ylim[0])
+    assert rawswarm_axes.get_ylim()[1] == pytest.approx(rand_swarm_ylim[1])
+
+    # Check contrast ylims match the desired ones.
+    assert contrast_axes.get_ylim()[0] == pytest.approx(rand_contrast_ylim[0])
+    assert contrast_axes.get_ylim()[1] == pytest.approx(rand_contrast_ylim[1])
+
+    # Check xtick labels.
+    idx_flat = [g for t in IDX for g in t]
+    swarm_xticks = [a.get_text() for a in rawswarm_axes.get_xticklabels()]
+    for j, xtick in enumerate(swarm_xticks):
+        assert xtick == "{}\nN = 30".format(idx_flat[j])
+
+    contrast_xticks = [a.get_text() for a in contrast_axes.get_xticklabels()]
+    assert contrast_xticks[1] == "5\nminus\n0"
+    assert contrast_xticks[3] == "2\nminus\n3"
+    assert contrast_xticks[5] == "1\nminus\n4"
+    assert contrast_xticks[6] == "6\nminus\n4"
+
+    # Check ylabels.
+    assert rawswarm_axes.get_ylabel() == "Raw swarmplot!"
+    assert contrast_axes.get_ylabel() == "Contrast..."
+
+
+
+
+
+def test_gardner_altman_paired():
+    base_mean = np.random.randint(-5, 5)
+    seed, ptp, df = create_dummy_dataset(base_mean=base_mean)
+
+
+    # Check that the plot data matches the raw data.
+    two_group_paired = load(df, idx=("1", "2"), id_col="idcol", paired=True)
+    f1 = two_group_paired.mean_diff.plot()
+    rawswarm_axes = f1.axes[0]
+    contrast_axes = f1.axes[1]
+    assert df['1'].tolist() == [l.get_ydata()[0] for l in rawswarm_axes.lines]
+    assert df['2'].tolist() == [l.get_ydata()[1] for l in rawswarm_axes.lines]
+
+
+    # Check that id_col must be specified.
+    err_to_catch = "`id_col` must be specified if `is_paired` is set to True."
+    with pytest.raises(IndexError, match=err_to_catch):
+        this_will_not_work = load(df, idx=("1", "2"), paired=True)


### PR DESCRIPTION
I added an option to specify existing axes for the new plots to go in. Most of the changes are in plotter.py. When the user specifies the axes using the parameter `ax=my_ax`, the rawdata plot is created in those axes, and the contrast plot is created as an inset axes next to those axes. This avoid creating an entirely new set of axes, since the inset is connected to the original axes. 

I did my best to maintain the spacing of the plots as best I understand them, but sometimes matplotlib spacing seems like wizardry to me, so I may have overlooked something.

I also modified one of the tests in the plotting test file and created a new test file. In my hands, the new code passes the existing tests, although it does throw a warning related to a DeprecationWarning for something that will change in python 3.8. Looks like this is only a problem in matplotlib 3.0, and it gets fixed in matplotlib 3.1.

For users who don't use this option, nothing should change. For users who do, the rawdata axes are not necessarily accessible using `FigName.axes[0]` because the specified axes might have a different index. The contrast axes can be accessed using `ax.contrast_axes` where `ax` is the specified axes.