### PR TITLE
Fixed bug in inset axes

### DIFF
--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -694,7 +694,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         # Compute the end of each x-axes line.
         rightend_ticks = np.array([len(i)-1 for i in idx]) + np.array(ticks_to_skip)
 
-        for ax in fig.axes:
+        for ax in [rawdata_axes, contrast_axes]:
             sns.despine(ax=ax, bottom=True)
 
             ylim = ax.get_ylim()


### PR DESCRIPTION
My code had a bug where the lines on the x axis of the estimation plot got drawn on every set of axes in the entire fig. Not a problem if all you have in the figure is the estimation plot, but still a problem if you have other.