### PR TITLE
Honor reflines_kwargs when float_contrast=False

### DIFF
--- a/dabest/_classes.py
+++ b/dabest/_classes.py
@@ -1209,6 +1209,12 @@ class EffectSizeDataFrame(object):
             pyplot.violinplot` command here, as a dict. If None, the following
             keywords are passed to violinplot : {'widths':0.5, 'vert':True,
             'showextrema':False, 'showmedians':False}.
+        slopegraph_kwargs : dict, default None
+            This will change the appearance of the lines used to join each pair
+            of observations when `show_pairs=True`. Pass any keyword arguments
+            accepted by matplotlib `plot()` function here, as a dict.
+            If None, the following keywords are
+            passed to plot() : {'linewidth':1, 'alpha':0.5}.
         reflines_kwargs : dict, default None
             This will change the appearance of the zero reference lines. Pass
             any keyword arguments accepted by the matplotlib Axes `hlines`

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -697,7 +697,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
         else:
             contrast_ylim_high, contrast_ylim_low = contrast_axes_ylim
         if contrast_ylim_low < 0 < contrast_ylim_high:
-            contrast_axes.axhline(y=0, lw=0.75, color=ytick_color)
+            contrast_axes.axhline(y=0, **reflines_kwargs)
 
         # Compute the end of each x-axes line.
         rightend_ticks = np.array([len(i)-1 for i in idx]) + np.array(ticks_to_skip)

--- a/dabest/plotter.py
+++ b/dabest/plotter.py
@@ -130,7 +130,7 @@ def EffectSizeDataFramePlotter(EffectSizeDataFrame, **plot_kwargs):
     if plot_kwargs["slopegraph_kwargs"] is None:
         slopegraph_kwargs = default_slopegraph_kwargs
     else:
-        slopegraph_kwargs = merge_two_dicts(slopegraph_kwargs,
+        slopegraph_kwargs = merge_two_dicts(default_slopegraph_kwargs,
                                             plot_kwargs["slopegraph_kwargs"])
 
 


### PR DESCRIPTION
Proposed fix for #87 

When using `float_contrast=False`, the zero reference line does not honor the attributes passed in `reflines_kwargs`.

I believe it would make sense that it does.
